### PR TITLE
[lang]/Makefile: add label '-fmarkdown-implicit_figures'

### DIFF
--- a/en/Makefile
+++ b/en/Makefile
@@ -33,7 +33,7 @@ $(BUILD_PATH)/epub/$(BOOKNAME): | medialink
 $(BUILD_PATH)/html/$(BOOKNAME):  | medialink
 	mkdir -p ../$(BUILD_PATH)/html
 	ln -s ../../../media ../$(BUILD_PATH)/html/media
-	pandoc $(TOC) --standalone --to=html5 -o ../$@.html $(CHAPTERS)
+	pandoc $(TOC) --standalone -fmarkdown-implicit_figures --to=html5 -o ../$@.html $(CHAPTERS)
 
 $(BUILD_PATH)/pdf/$(BOOKNAME): | medialink
 	mkdir -p ../$(BUILD_PATH)/pdf

--- a/es/Makefile
+++ b/es/Makefile
@@ -33,7 +33,7 @@ $(BUILD_PATH)/epub/$(BOOKNAME): | medialink
 $(BUILD_PATH)/html/$(BOOKNAME):  | medialink
 	mkdir -p ../$(BUILD_PATH)/html
 	ln -s ../../../media ../$(BUILD_PATH)/html/media
-	pandoc $(TOC) --standalone --to=html5 -o ../$@.html $(CHAPTERS)
+	pandoc $(TOC) --standalone -fmarkdown-implicit_figures --to=html5 -o ../$@.html $(CHAPTERS)
 
 $(BUILD_PATH)/pdf/$(BOOKNAME): | medialink
 	mkdir -p ../$(BUILD_PATH)/pdf

--- a/it/Makefile
+++ b/it/Makefile
@@ -33,7 +33,7 @@ $(BUILD_PATH)/epub/$(BOOKNAME): | medialink
 $(BUILD_PATH)/html/$(BOOKNAME):  | medialink
 	mkdir -p ../$(BUILD_PATH)/html
 	ln -s ../../../media ../$(BUILD_PATH)/html/media
-	pandoc $(TOC) --standalone --to=html5 -o ../$@.html $(CHAPTERS)
+	pandoc $(TOC) --standalone -fmarkdown-implicit_figures --to=html5 -o ../$@.html $(CHAPTERS)
 
 $(BUILD_PATH)/pdf/$(BOOKNAME): | medialink
 	mkdir -p ../$(BUILD_PATH)/pdf


### PR DESCRIPTION
This label avoid the HTML to be built with captions under the screenshots. We don't need them and make my life easier, since, for now, i wil be building the markdown versions of the guide from the generated HTML guide. This will change in future, for now that's the best way to keep the format consistent