### PR TITLE
ch02: improving troubleshooting of hardware wallets

### DIFF
--- a/en/ch02.md
+++ b/en/ch02.md
@@ -60,6 +60,7 @@ Monero GUI currently supports the hardware wallet models Ledger Nano S/X and Tre
 
 ### Prepare your device
 If you are using a Ledger Nano S/X, please make sure:
+
 + Your device is plugged in and unlocked
 + Your device has already been initialized before (your device already has a recovery seed)
 + Your device has the most recent firmware version (available in Manager section of Ledger Live desktop app) (see instructions for [Nano S](https://support.ledger.com/hc/en-us/articles/360002731113-Update-Ledger-Nano-S-firmware)/[Nano X](https://support.ledger.com/hc/en-us/articles/360013349800-Update-Ledger-Nano-X-firmware))
@@ -68,10 +69,11 @@ If you are using a Ledger Nano S/X, please make sure:
 + Your computer has no other cryptocurrency wallet running in the background, like Ledger Live
 
 If you are using a Trezor Model T, please make sure:
+
 + Your device is plugged in and unlocked
 + Your device has already been initialized before (your device already has a recovery seed)
 + Your device has the most recent firmware version (available in Trezor Wallet) ([see instructions](https://wiki.trezor.io/Firmware_update))
-+ Your computer has no other cryptocurrency wallet running in the background, like Trezor Wallet
++ Your computer has no other cryptocurrency wallet running in the background, like Trezor Wallet, Trezor Suite, or Exodus Wallet
 
 ### Create a wallet from your hardware wallet device
 ![2.4.1](media/create_hardware_wallet.png)
@@ -87,12 +89,24 @@ On this page you can create a new Monero wallet file from your hardware wallet d
 (6) **Device name:** Select the hardware wallet you want to use. Monero GUI currently supports the hardware wallet models Ledger Nano S/X and Trezor Model T.  
 
 ### Ledger troubleshooting
-+ If you can't connect to your Ledger, try restarting your computer, using a different USB cable, changing the USB port, or connecting to a different computer. Avoid using USB hubs.
++ Check if your device is plugged in and unlocked
++ Check if your device has already been initialized before (your device already has a recovery seed)
++ Check if your device has the most recent firmware version (available in Manager section of Ledger Live desktop app) (see instructions for [Nano S](https://support.ledger.com/hc/en-us/articles/360002731113-Update-Ledger-Nano-S-firmware)/[Nano X](https://support.ledger.com/hc/en-us/articles/360013349800-Update-Ledger-Nano-X-firmware))
++ Check if your device has the Monero app installed (available in Ledger Live desktop app)
++ Check if your device is running the Monero app
++ Close any cryptocurrency wallet running in the background, like Ledger Live
++ Restart your computer and try again
++ If you still can't connect to your Ledger, try using a different USB cable, changing the USB port, or connecting to a different computer. Avoid using USB hubs.
 + If your Monero GUI wallet is slow while using Ledger, make sure you're allowing your Ledger device to export the private view key to your computer. You should only export the private view key when using official Monero software.
 + Step by step guide for all operating systems (StackExchange): [How do I generate a Ledger Monero wallet with the GUI (monero-wallet-gui)?](https://monero.stackexchange.com/questions/9901/how-do-i-generate-a-ledger-monero-wallet-with-the-gui-monero-wallet-gui)
 
 ### Trezor troubleshooting
-+ If you can't connect to your Trezor, try restarting your computer, using a different USB cable, changing the USB port, or connecting to a different computer. Avoid using USB hubs.
++ Check if your device is plugged in and unlocked
++ Check if your device has already been initialized before (your device already has a recovery seed)
++ Check if your device has the most recent firmware version (available in Trezor Wallet) ([see instructions](https://wiki.trezor.io/Firmware_update))
++ Close any cryptocurrency wallet running in the background, like Trezor Wallet, Trezor Suite, or Exodus Wallet
++ Restart your computer and try again
++ If you still can't connect to your Trezor, try using a different USB cable, changing the USB port, or connecting to a different computer. Avoid using USB hubs.
 + If you still can't connect, try installing [Trezor Bridge](https://wiki.trezor.io/Trezor_Bridge). It's usually not necessary to install Trezor Bridge, but some systems may require it to communicate with Trezor.
 + Step by step guide for all operating systems (StackExchange): [How do I generate a Trezor Monero wallet with the GUI (monero-wallet-gui)?](https://monero.stackexchange.com/questions/11437/how-do-i-generate-a-trezor-monero-wallet-with-the-gui-monero-wallet-gui/)
 


### PR DESCRIPTION
- adding a line break in _Prepare your device_ section (list items are not being displayed correctly in pdf)
- adding Trezor Suite and Exodus Wallet (which has official support by Trezor)
- adding all known source of problems in troubleshooting sections of Ledger and Trezor wallets

see: https://github.com/monero-project/monero-gui/issues/3296